### PR TITLE
Added `--depth 1` to avoid pulling the full git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To create a secure Android emulator image with the latest security patches, foll
 2. Fetch the security patch tag across all AOSP repositories:
 
    ```shell
-   2. repo forall -p -c 'git fetch aosp android-security-14.0.0_r9'
+   2. repo forall -p -c 'git fetch aosp android-security-14.0.0_r9 --depth 1'
    ```
 
    Replace `android-security-14.0.0_r9` with the actual security patch tag.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file to improve the process of fetching security patches for an Android emulator image.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54): Updated the command to fetch security patches to include the `--depth 1` option, which reduces the amount of data fetched.